### PR TITLE
changed slice thickness to a number from string type

### DIFF
--- a/gdcdictionary/schemas/cr_image.yaml
+++ b/gdcdictionary/schemas/cr_image.yaml
@@ -148,7 +148,7 @@ properties:
 
   slice_thickness:
     description: (0018, 0050) Slice Thickness
-    type: string
+    type: number
 
   sop_class_uid:
     description: (0008, 0016) SOP Class UID

--- a/gdcdictionary/schemas/ct_image.yaml
+++ b/gdcdictionary/schemas/ct_image.yaml
@@ -148,7 +148,7 @@ properties:
 
   slice_thickness:
     description: (0018, 0050) Slice Thickness
-    type: string
+    type: number
 
   sop_class_uid:
     description: (0008, 0016) SOP Class UID

--- a/gdcdictionary/schemas/dx_image.yaml
+++ b/gdcdictionary/schemas/dx_image.yaml
@@ -148,7 +148,7 @@ properties:
 
   slice_thickness:
     description: (0018, 0050) Slice Thickness
-    type: string
+    type: number
 
   sop_class_uid:
     description: (0008, 0016) SOP Class UID


### PR DESCRIPTION
One potentially breaking change: changed property type of "slice_thickness" from "string" to "number". 
Currently, no slice_thickness is reported with letters, only numbers with decimals, so even though it's technically a breaking change, it shouldn't invalidate any data currently in sheepdog. 