### PR TITLE
updating age limit to 90 max

### DIFF
--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -55,7 +55,7 @@ properties:
   age_at_imaging:
     description: Age of the patient in years at the time the imaging study was performed.
     type: number
-    maximum: 89
+    maximum: 90
     minimum: 0
 
   body_part_examined:


### PR DESCRIPTION
The ACR data has some ages of 90. They've said this is the maximum, and any ages greater than 90 will automatically be set to 90.