### PR TITLE
v0.5.5b: updates to case node based on 6/17 working group

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -303,15 +303,7 @@ properties:
       - Wallis and Futuna
       - Samoa
       - Yemen
-
-  covid19_treatment_info:
-    description: Indicates whether detailed treatment information is available for the subject.
-    type: boolean
-
-  covid19_ventilator_indicator:
-    description: Indicates whether the subject has been on a ventilator as part of their COVID-19 treatment.
-    type: boolean
-
+      
   ethnicity:
     term:
       $ref: "_terms.yaml#/ethnicity"


### PR DESCRIPTION
v0.5.5b: updates to case node based on 6/17 working group... originally added covid_19 to some of the new properties, but ended up not needing these covid-specific questions and instead the group only wanted more broad questions about treatment and ventilator.