### PR TITLE
v0.6.7: updating series level notes to be file nodes.

### DIFF
--- a/gdcdictionary/schemas/cr_series.yaml
+++ b/gdcdictionary/schemas/cr_series.yaml
@@ -26,7 +26,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: ct_series
+        backref: cr_series
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/cr_series.yaml
+++ b/gdcdictionary/schemas/cr_series.yaml
@@ -26,7 +26,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: ct_instances
+        backref: ct_series
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/cr_series.yaml
+++ b/gdcdictionary/schemas/cr_series.yaml
@@ -4,10 +4,10 @@ id: "cr_series"
 title: CR Series
 type: object
 namespace: https://data.midrc.org/
-category: imaging_series
+category: imaging_data_file
 program: '*'
 project: '*'
-description: Information related to a CR imaging series to which one or more computed radiographs belong.
+description: The image files and metadata related to a series of CR images to which one or more computed radiographs belong.
 additionalProperties: false
 submittable: true
 validators: null
@@ -18,19 +18,35 @@ systemProperties:
   - state
   - created_datetime
   - updated_datetime
+  - file_state
+  - error_type
 
 links:
-  - name: radiography_exams
-    backref: cr_series
-    label: related_to
-    target_type: radiography_exam
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: ct_instances
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: radiography_exams
+        backref: cr_series
+        label: related_to
+        target_type: radiography_exam
+        multiplicity: many_to_one
+        required: false
 
 required:
   - submitter_id
   - type
-  - radiography_exams
+  - file_name
+  - file_size
+  - md5sum
+  - data_format
+  - data_type
+  - data_category
 
 uniqueKeys:
   - [id]
@@ -38,13 +54,33 @@ uniqueKeys:
 
 properties:
 
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   contrast_bolus_agent:
     description: "(0018, 0010) Contrast/Bolus Agent"
     type: array
     items:
       type: string
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - "CT"
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - "DCM"
+      - "nii.gz"
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - "DICOM"
+      - "NIfTI"
 
   detector_type:
     description: (0018, 7004) Detector Type
@@ -53,6 +89,10 @@ properties:
       - SCINTILLATOR
       - STORAGE
       - FILM
+
+  file_description:
+    description: Any additional text to give this file context in its study.
+    type: string
 
   image_type:
     description: (0008, 0008) Image Type
@@ -123,6 +163,10 @@ properties:
       - RLO
       - LLO
 
+  core_metadata_collections:
+    description: The submitter_id or id of the core_metadata_collection to which the CR series belongs, i.e., a link to a record in the parent node.
+    $ref: "_definitions.yaml#/to_one"
+
   radiography_exams:
-    description: The submitter_id or id of the radiography_exam this dx_series belongs to, i.e., a link to a record in the parent node.
+    description: The submitter_id or id of the radiography_exam this CR series belongs to, i.e., a link to a record in the parent node.
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/ct_series.yaml
+++ b/gdcdictionary/schemas/ct_series.yaml
@@ -4,10 +4,10 @@ id: "ct_series"
 title: CT Series
 type: object
 namespace: https://data.midrc.org/
-category: imaging_series
+category: imaging_data_file
 program: '*'
 project: '*'
-description: Information related to a CT imaging series consisting of a stack of CT slices.
+description: The image files and metadata related to a series of CT images consisting of a stack of CT slices.
 additionalProperties: false
 submittable: true
 validators: null
@@ -18,19 +18,35 @@ systemProperties:
   - state
   - created_datetime
   - updated_datetime
+  - file_state
+  - error_type
 
 links:
-  - name: ct_scans
-    backref: ct_series
-    label: related_to
-    target_type: ct_scan
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: ct_instances
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: ct_scans
+        backref: ct_series
+        label: related_to
+        target_type: ct_scan
+        multiplicity: many_to_one
+        required: false
 
 required:
   - submitter_id
   - type
-  - ct_scans
+  - file_name
+  - file_size
+  - md5sum
+  - data_format
+  - data_type
+  - data_category
 
 uniqueKeys:
   - [id]
@@ -38,7 +54,7 @@ uniqueKeys:
 
 properties:
 
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   acquisition_type:
     description: (0018, 9302) Acquisition Type
@@ -48,6 +64,26 @@ properties:
       - CONSTANT_ANGLE
       - STATIONARY
       - FREE
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - "CT"
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - "DCM"
+      - "nii.gz"
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - "DICOM"
+      - "NIfTI"
 
   contrast_bolus_agent:
     description: "(0018, 0010) Contrast/Bolus Agent"
@@ -63,6 +99,10 @@ properties:
 
   exposure_modulation_type:
     description: (0018, 9323) Exposure Modulation Type
+    type: string
+
+  file_description:
+    description: Any additional text to give this file context in its study.
     type: string
 
   image_type:
@@ -134,6 +174,10 @@ properties:
     type: array
     items:
       type: number
+
+  core_metadata_collections:
+    description: The submitter_id or id of the core_metadata_collection to which the CT series belongs, i.e., a link to a record in the parent node.
+    $ref: "_definitions.yaml#/to_one"
 
   ct_scans:
     description: The submitter_id or id of the ct_scan this ct_series belongs to, i.e., a link to a record in the parent node.

--- a/gdcdictionary/schemas/ct_series.yaml
+++ b/gdcdictionary/schemas/ct_series.yaml
@@ -26,7 +26,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: ct_instances
+        backref: ct_series
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/dx_series.yaml
+++ b/gdcdictionary/schemas/dx_series.yaml
@@ -26,7 +26,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: dx_instances
+        backref: dx_series
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/dx_series.yaml
+++ b/gdcdictionary/schemas/dx_series.yaml
@@ -4,10 +4,10 @@ id: "dx_series"
 title: DX Series
 type: object
 namespace: https://data.midrc.org/
-category: imaging_series
+category: imaging_data_file
 program: '*'
 project: '*'
-description: Information related to a DX imaging series to which one or more digital radiographs (x-rays) belong.
+description: The image files and metadata related to a series of DX images to which one or more digital radiographs (x-rays) belong.
 additionalProperties: false
 submittable: true
 validators: null
@@ -18,19 +18,35 @@ systemProperties:
   - state
   - created_datetime
   - updated_datetime
+  - file_state
+  - error_type
 
 links:
-  - name: radiography_exams
-    backref: dx_series
-    label: related_to
-    target_type: radiography_exam
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: dx_instances
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: radiography_exams
+        backref: dx_series
+        label: related_to
+        target_type: radiography_exam
+        multiplicity: many_to_one
+        required: false
 
 required:
   - submitter_id
   - type
-  - radiography_exams
+  - file_name
+  - file_size
+  - md5sum
+  - data_format
+  - data_type
+  - data_category
 
 uniqueKeys:
   - [id]
@@ -38,13 +54,33 @@ uniqueKeys:
 
 properties:
 
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   contrast_bolus_agent:
     description: "(0018, 0010) Contrast/Bolus Agent"
     type: array
     items:
       type: string
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - "DX"
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - "DCM"
+      - "nii.gz"
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - "DICOM"
+      - "NIfTI"
 
   detector_type:
     description: (0018, 7004) Detector Type
@@ -53,6 +89,10 @@ properties:
       - SCINTILLATOR
       - STORAGE
       - FILM
+
+  file_description:
+    description: Any additional text to give this file context in its study.
+    type: string
 
   image_type:
     description: (0008, 0008) Image Type
@@ -123,6 +163,10 @@ properties:
       - RLO
       - LLO
 
+  core_metadata_collections:
+    description: The submitter_id or id of the core_metadata_collection to which the DX series belongs, i.e., a link to a record in the parent node.
+    $ref: "_definitions.yaml#/to_one"
+
   radiography_exams:
-    description: The submitter_id or id of the radiography_exam this dx_series belongs to, i.e., a link to a record in the parent node.
+    description: The submitter_id or id of the radiography_exam this DX series belongs to, i.e., a link to a record in the parent node.
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/mr_series.yaml
+++ b/gdcdictionary/schemas/mr_series.yaml
@@ -26,7 +26,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: mr_instances
+        backref: mr_series
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/mr_series.yaml
+++ b/gdcdictionary/schemas/mr_series.yaml
@@ -4,10 +4,10 @@ id: "mr_series"
 title: MR Series
 type: object
 namespace: https://data.midrc.org/
-category: imaging_series
+category: imaging_data_file
 program: '*'
 project: '*'
-description: Information related to an imaging series to which one or more MR (Magnetic Resonance) images belong.
+description: The image files and metadata related to a series of MR images to which one or more MR (Magnetic Resonance) images belong.
 additionalProperties: false
 submittable: true
 validators: null
@@ -18,19 +18,35 @@ systemProperties:
   - state
   - created_datetime
   - updated_datetime
+  - file_state
+  - error_type
 
 links:
-  - name: mr_exams
-    backref: mr_series
-    label: related_to
-    target_type: mr_exam
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
+    subgroup:
+      - name: core_metadata_collections
+        backref: mr_instances
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
+      - name: mr_exams
+        backref: mr_series
+        label: related_to
+        target_type: mr_exam
+        multiplicity: many_to_one
+        required: false
 
 required:
   - submitter_id
   - type
-  - mr_exams
+  - file_name
+  - file_size
+  - md5sum
+  - data_format
+  - data_type
+  - data_category
 
 uniqueKeys:
   - [id]
@@ -38,13 +54,33 @@ uniqueKeys:
 
 properties:
 
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   contrast_bolus_agent:
     description: (0018, 0010) Contrast/Bolus Agent
     type: array
     items:
       type: string
+
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    enum:
+      - "MR"
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    enum:
+      - "DCM"
+      - "nii.gz"
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    enum:
+      - "DICOM"
+      - "NIfTI"
 
   detector_type:
     description: (0018, 7004) Detector Type
@@ -53,6 +89,10 @@ properties:
       - SCINTILLATOR
       - STORAGE
       - FILM
+
+  file_description:
+    description: Any additional text to give this file context in its study.
+    type: string      
 
   image_type:
     description: (0008, 0008) Image Type
@@ -134,6 +174,10 @@ properties:
     items:
       type: number
 
+  core_metadata_collections:
+    description: The submitter_id or id of the core_metadata_collection to which the MR series belongs, i.e., a link to a record in the parent node.
+    $ref: "_definitions.yaml#/to_one"
+
   mr_exams:
-    description: The submitter_id or id of the mr_exam this mr_series belongs to, i.e., a link to a record in the parent node.
+    description: The submitter_id or id of the mr_exam this MR series belongs to, i.e., a link to a record in the parent node.
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
Chris - I made these updates to the series level nodes, but I'm a little worried because all of the files props are now required and none of the current series nodes have these properties completed... is that going to be a problem? I think we can ensure all of these fields are completed going forward, but I wanted to make sure this isn't going to be a problem for the "legacy" data. iF it is, I think I can add these as new nodes (call them series_file nodes?). Let me know what you think.