### PR TITLE
updated age properties, age_at_index and age_at_imaging

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -42,8 +42,16 @@ properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   age_at_index:
-    description: The subject's age at the time of the study.
+    description: The subject's age at the time of the study. To indicate ages greater than 89 years, please use the property 'age_at_index_gt89'.
     type: number
+    maximum: 89
+    minimum: 0
+
+  age_at_index_gt89:
+    description: Indicates whether the subject's age at the time of the study was greater than 89 years.
+    enum:
+      - "Yes"
+      - "No"
 
   covid19_positive:
     description: An indicator of whether the patient has ever had a positive COVID-19 test.

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -72,10 +72,16 @@ properties:
       type: string
 
   age_at_imaging:
-    description: Age of the patient in years at the time the imaging study was performed.
+    description: Age of the patient in years at the time the imaging study was performed. To indicate ages greater than 89 years, please use the property 'age_at_imaging_gt89'.
     type: number
-    maximum: 90
+    maximum: 89
     minimum: 0
+
+  age_at_imaging_gt89:
+    description: Indicates whether the age of the patient in years at the time the imaging study was performed is greater than 89 years.
+    enum:
+      - "Yes"
+      - "No"
 
   body_part_examined:
     description: (0018, 0015) Body Part Examined.


### PR DESCRIPTION
In order to abide by the HIPAA privacy guidelines, ages over 89 are not permitted. Thus, we're adding two new properties:
age_at_index_gt89 on case node and age_at_imaging_gt89 on imaging_study node, as well as putting limits on the max/min age submittable to the age_at_index and age_at_imaging properties of 0 (min) and 89 (max).