### PR TITLE
v0.7.9: removing harmonized study description and adding indeterminate for covid test props

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -58,6 +58,7 @@ properties:
     enum:
       - "Yes"
       - "No"
+      - "Indeterminate"
       - Not Reported
 
   country_of_origin:

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -94,11 +94,6 @@ properties:
     description: The LOINC system or body part examined associated with the assigned LOINC code.
     type: string
 
-  midrc_harmonized_study_description:
-    description: A standardized representation mapped by MIDRC Data Quality and Harmonization subcommittee to the study_description property in submitted imaging data.
-    enum:
-      - TBD
-
   study_description:
     description: (0008, 1030) Study Description.
     type: string

--- a/gdcdictionary/schemas/measurement.yaml
+++ b/gdcdictionary/schemas/measurement.yaml
@@ -67,6 +67,7 @@ properties:
   test_result_text:
     description: The measured result of the test described using a list of enumerations.
     enum:
+      - Indeterminate
       - Negative
       - Positive
       - Not Reported


### PR DESCRIPTION
See tickets below for details:
- Harmonized study description: https://ctds-planx.atlassian.net/browse/MIDRC-66
- Indeterminate options: https://ctds-planx.atlassian.net/jira/software/projects/MIDRC/boards/133?selectedIssue=MIDRC-57
