### PR TITLE
Update decription for days from positive and negative tests

### DIFF
--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -59,13 +59,13 @@ properties:
       type: string
 
   days_from_study_to_neg_covid_test:
-    description: The number of days from the imaging study to the patient's negative COVID-19 test(s).A positive value for this property means that a <positive/negative> COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
+    description: The number of days from the imaging study to the patient's negative COVID-19 test(s).A positive value for this property means that a negative COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
     type: array
     items:
       type: integer
 
   days_from_study_to_pos_covid_test:
-    description: The number of days from the imaging study to the patient's positive COVID-19 test(s).A positive value for this property means that a <positive/negative> COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
+    description: The number of days from the imaging study to the patient's positive COVID-19 test(s).A positive value for this property means that a positive COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
     type: array
     items:
       type: integer

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -59,17 +59,17 @@ properties:
       type: string
 
   days_from_study_to_neg_covid_test:
-    description: The number of days from the imaging study to the patient's negative COVID-19 test(s).
+    description: The number of days from the imaging study to the patient's negative COVID-19 test(s).A positive value for this property means that a <positive/negative> COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
     type: array
     items:
       type: integer
 
   days_from_study_to_pos_covid_test:
-    description: The number of days from the imaging study to the patient's positive COVID-19 test(s).
+    description: The number of days from the imaging study to the patient's positive COVID-19 test(s).A positive value for this property means that a <positive/negative> COVID-19 test result was obtained for the patient that many days after the imaging study was performed. A negative value indicates that the COVID-19 test was performed prior to the date of imaging. This property takes a list of values, each of which represents a COVID-19 test for the patient undergoing the imaging study.
     type: array
     items:
       type: integer
- 
+
   days_to_study:
     description: The number of days between the case's index date and the date of the imaging study.
     type: number


### PR DESCRIPTION
Jira Ticket: [MIDRC-105](https://ctds-planx.atlassian.net/browse/MIDRC-105)

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

Add to the data dictionary definition of the two derived properties on the imaging_study node that clarifies what a positive and negative value means
days_from_study_to_neg_covid_test and days_from_study_to_pos_covid_test


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
