### PR TITLE
v0.8.0: added full_name property to the dataset node

### DIFF
--- a/gdcdictionary/schemas/dataset.yaml
+++ b/gdcdictionary/schemas/dataset.yaml
@@ -90,6 +90,10 @@ properties:
     description: The primary type of disease studied in this dataset, if applicable.
     type: string
 
+  full_name:
+    description: The full name of the dataset or publication.
+    type: string
+
   license:
     description: The license under which the daaset has been published.
     type: string


### PR DESCRIPTION
Adding **full_name** to the dataset node so manual entry of this does not need to be done twice (i.e. at MIDRC and MDS ingestion). See this ticket for full detail: https://ctds-planx.atlassian.net/jira/software/projects/MIDRC/boards/133?selectedIssue=MIDRC-116. 