### PR TITLE
Update age properties' descriptions

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -42,7 +42,7 @@ properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   age_at_index:
-    description: The subject's age at the time of the study. To indicate ages greater than 89 years, please use the property 'age_at_index_gt89'.
+    description: The study participant’s age, in years, at the index event. The index event is determined by the data submitter and used as an anchor date for all temporal variables. Note that an age of 0 indicates a participant who is younger than 1 year old. For participants with ages greater than 89 years, please use the property 'age_at_index_gt89'.
     type: number
     maximum: 89
     minimum: 0

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -41,7 +41,7 @@ properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   age_at_imaging:
-    description: Age of the patient in years at the time the imaging study was performed. To indicate ages greater than 89 years, please use the property 'age_at_imaging_gt89'.
+    description: The study participant’s age, in years, at the time the imaging study was performed. Note that an age of 0 indicates a participant who is younger than 1 year old. For participants with ages greater than 89 years, please use the property 'age_at_index_gt89'.
     type: number
     maximum: 89
     minimum: 0


### PR DESCRIPTION
Jira Ticket: [MIDRC-184](https://ctds-planx.atlassian.net/browse/MIDRC-184)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

Update the descriptions for the two age properties (listed below) to describe these are collected in a number of years and that study participants who are younger than 1 year old will be listed as 0 years.

**case.age_at_index**
- **current**: The subject's age at the time of the study. To indicate ages greater than 89 years, please use the property 'age_at_index_gt89'.
- **new**: The study participant’s age, in years, at the index event. The index event is determined by the data submitter and used as an anchor date for all temporal variables. Note that an age of 0 indicates a participant who is younger than 1 year old. For participants with ages greater than 89 years, please use the property 'age_at_index_gt89'.

**imaging_study.age_at_imaging**
- **current**: Age of the patient in years at the time the imaging study was performed. To indicate ages greater than 89 years, please use the property 'age_at_imaging_gt89'.
- **new**: The study participant’s age, in years, at the time the imaging study was performed. Note that an age of 0 indicates a participant who is younger than 1 year old. For participants with ages greater than 89 years, please use the property 'age_at_index_gt89'.


[MIDRC-184]: https://ctds-planx.atlassian.net/browse/MIDRC-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ