### PR TITLE
v1.2.3: Updating newer modality series nodes

### DIFF
--- a/gdcdictionary/schemas/mg_series_file.yaml
+++ b/gdcdictionary/schemas/mg_series_file.yaml
@@ -56,6 +56,12 @@ properties:
 
   $ref: "_definitions.yaml#/data_file_properties"
 
+  code_meaning:
+    description: "(0008,0104) Code Meaning. Note that code_meaning is pulled from the View Code Sequence (0054,0220)"
+    type: array
+    items:
+      type: string
+  
   contrast_bolus_agent:
     description: "(0018, 0010) Contrast/Bolus Agent"
     type: array

--- a/gdcdictionary/schemas/rf_series_file.yaml
+++ b/gdcdictionary/schemas/rf_series_file.yaml
@@ -70,6 +70,24 @@ properties:
       - STORAGE
       - FILM
 
+  image_type:
+    description: (0008, 0008) Image Type
+    type: array
+    items:
+      type: string
+
+  imager_pixel_spacing:
+    description: (0018, 1164) Imager Pixel Spacing
+    type: array
+    items:
+      type: number
+
+  lossy_image_compression:
+    description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
+    enum:
+      - "00"
+      - "01"
+
   manufacturer:
     description: (0008, 0070) Manufacturer
     type: string
@@ -95,6 +113,16 @@ properties:
   series_uid:
     description: The UID or unique identification code of the imaging series; (0020, 000e) Series Instance UID.
     type: string
+
+  spatial_resolution:
+    description: (0018, 1050) Spatial Resolution
+    type: number
+
+  view_position:
+    description: (0018, 5101) View Position
+    type: array
+    items:
+      type: string
 
   data_category:
     term:

--- a/gdcdictionary/schemas/us_series_file.yaml
+++ b/gdcdictionary/schemas/us_series_file.yaml
@@ -74,7 +74,7 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
-  region_spacial_format:
+  region_spatial_format:
     description: (0018,6012) Region Spatial Format
     type: array
     items:
@@ -82,7 +82,7 @@ properties:
         - "0000H: None or not applicable"
         - "0001H: 2D (tissue or flow)"
         - "0002H: M-Mode (tissue or flow)"
-        - "0003H: Spectral (CW or PW Doppler"
+        - "0003H: Spectral (CW or PW Doppler)"
         - "0004H: Wave form (physiological traces, Doppler traces,...)"
         - "0005H: Graphics"
 
@@ -133,10 +133,6 @@ properties:
     enum:
       - "DICOM"
       - "NIfTI"
-
-  # file_description:
-  #   description: Any additional text to give this file context in its study.
-  #   type: string
 
   core_metadata_collections:
     description: The submitter_id or id of the core_metadata_collection to which the us_series_file belongs, i.e., a link to a record in the parent node.

--- a/gdcdictionary/schemas/us_series_file.yaml
+++ b/gdcdictionary/schemas/us_series_file.yaml
@@ -56,10 +56,6 @@ properties:
 
   $ref: "_definitions.yaml#/data_file_properties"
 
-  doppler_images:
-    description: Indicates whether this series includes Doppler images included (can we use DICOM (0018, 6012) for this?)
-    type: boolean
-
   lossy_image_compression:
     description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
     enum:
@@ -78,9 +74,17 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
-  multiframe_images:
-    description: Indicates whether this series includes multiframe images.
-    type: boolean
+  region_spacial_format:
+    description: (0018,6012) Region Spatial Format
+    type: array
+    items:
+      enum:
+        - "0000H: None or not applicable"
+        - "0001H: 2D (tissue or flow)"
+        - "0002H: M-Mode (tissue or flow)"
+        - "0003H: Spectral (CW or PW Doppler"
+        - "0004H: Wave form (physiological traces, Doppler traces,...)"
+        - "0005H: Graphics"
 
   series_description:
     description: A general description of or additional information about the imaging series; (0008, 103e) Series Description.

--- a/gdcdictionary/schemas/xa_series_file.yaml
+++ b/gdcdictionary/schemas/xa_series_file.yaml
@@ -56,11 +56,37 @@ properties:
 
   $ref: "_definitions.yaml#/data_file_properties"
 
+  body_part_examined:
+    description: (0018, 0015) Body Part Examined.
+    type: array
+    items:
+      type: string
+
+  contrast_bolus_agent:
+    description: "(0018, 0010) Contrast/Bolus Agent"
+    type: array
+    items:
+      type: string
+
+  detector_type:
+    description: (0018, 7004) Detector Type
+    enum:
+      - DIRECT
+      - SCINTILLATOR
+      - STORAGE
+      - FILM
+
   image_type:
     description: (0008, 0008) Image Type
     type: array
     items:
       type: string
+
+  imager_pixel_spacing:
+    description: (0018, 1164) Imager Pixel Spacing
+    type: array
+    items:
+      type: number
 
   lossy_image_compression:
     description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
@@ -80,6 +106,20 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  pixel_spacing:
+    description: (0028, 0030) Pixel Spacing
+    type: array
+    items:
+      type: number
+
+  radiation_setting:
+    description: (0018, 1155) Radiation Setting
+    type: array
+    items:
+      enum:
+        - "SC: low dose exposure generally corresponding to fluoroscopic settings (e.g., preparation for diagnostic quality image acquisition)"
+        - "GR: high dose for diagnostic quality image acquisition (also called digital spot or cine)"
+
   series_description:
     description: A general description of or additional information about the imaging series; (0008, 103e) Series Description.
     type: string
@@ -87,6 +127,16 @@ properties:
   series_uid:
     description: The UID or unique identification code of the imaging series; (0020, 000e) Series Instance UID.
     type: string
+
+  spatial_resolution:
+    description: (0018, 1050) Spatial Resolution
+    type: number
+
+  view_position:
+    description: (0018, 5101) View Position
+    type: array
+    items:
+      type: string
 
   data_category:
     term:


### PR DESCRIPTION
Updating new modality series nodes based on discussions during the DMSWG and DSIT meetings. Details can be found here: https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1432846337/Data+Model+Release+1.2.3+Approved.
