### PR TITLE
v1.2.7: Updating imaging_study and series-level properties to accommo…

### DIFF
--- a/gdcdictionary/schemas/cr_series_file.yaml
+++ b/gdcdictionary/schemas/cr_series_file.yaml
@@ -70,6 +70,21 @@ properties:
       - STORAGE
       - FILM
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/ct_series_file.yaml
+++ b/gdcdictionary/schemas/ct_series_file.yaml
@@ -81,6 +81,21 @@ properties:
     description: (0018, 9323) Exposure Modulation Type
     type: string
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/dx_series_file.yaml
+++ b/gdcdictionary/schemas/dx_series_file.yaml
@@ -72,6 +72,21 @@ properties:
       - STORAGE
       - FILM
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -74,6 +74,10 @@ properties:
     description: The number of days between the case's index date and the date of the imaging study.
     type: number
 
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study.
+    type: boolean
+
   loinc_code:
     description: The LOINC code assigned based on the study description provided.
     type: string

--- a/gdcdictionary/schemas/mg_series_file.yaml
+++ b/gdcdictionary/schemas/mg_series_file.yaml
@@ -76,6 +76,21 @@ properties:
       - STORAGE
       - FILM
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/mr_series_file.yaml
+++ b/gdcdictionary/schemas/mr_series_file.yaml
@@ -62,6 +62,21 @@ properties:
     items:
       type: string
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/nm_series_file.yaml
+++ b/gdcdictionary/schemas/nm_series_file.yaml
@@ -62,6 +62,21 @@ properties:
     items:
       type: string
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   lossy_image_compression:
     description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
     enum:

--- a/gdcdictionary/schemas/pt_series_file.yaml
+++ b/gdcdictionary/schemas/pt_series_file.yaml
@@ -66,6 +66,21 @@ properties:
     description: Indicates whether a computed tomography image(s) are assocated with this PET scan (e.g. PET/CT).
     type: boolean
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   lossy_image_compression:
     description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
     enum:

--- a/gdcdictionary/schemas/rf_series_file.yaml
+++ b/gdcdictionary/schemas/rf_series_file.yaml
@@ -70,6 +70,21 @@ properties:
       - STORAGE
       - FILM
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array

--- a/gdcdictionary/schemas/us_series_file.yaml
+++ b/gdcdictionary/schemas/us_series_file.yaml
@@ -56,6 +56,21 @@ properties:
 
   $ref: "_definitions.yaml#/data_file_properties"
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   lossy_image_compression:
     description: (0028, 2110) Lossy Image Compression; Note, if an image is compressed with a lossy algorithm, the Attribute Lossy Image Compression (0028,2110) is set to "01". Subsequently, if the image is decompressed and transferred in uncompressed format, this Attribute value remains "01".
     enum:

--- a/gdcdictionary/schemas/xa_series_file.yaml
+++ b/gdcdictionary/schemas/xa_series_file.yaml
@@ -76,6 +76,21 @@ properties:
       - STORAGE
       - FILM
 
+  image_data_modification_method:
+    description: A MIDRC classification describing specific methods (e.g., software tools, processes) used to modify the study series. More information can be found at midrc.org. 
+    type: integer
+
+  image_data_modification_type:
+    description: A categorical description of the type of image modification performed on the study series.
+    enum:
+      - Removal of alphanumeric characters
+      - Defacing
+      - Skull-stripping
+
+  image_data_modified:
+    description: An indicator of whether any post-clinical modification of image pixel data has been performed on the study series.
+    type: boolean
+
   image_type:
     description: (0008, 0008) Image Type
     type: array


### PR DESCRIPTION
The changes for 1.2.7 include additional properties to the imaging_study and series-level nodes as described in the meeting notes [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1478230017/DSIT+Meeting+Notes+2023-12-14) (see action items), and the voting page [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1480327169/Data+Model+Release+1.2.7+Approved).