### PR TITLE
v1.2.9: Change MR diffusion_gradient prop & removing "unused" props

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -203,16 +203,6 @@ data_file_properties:
     $ref: "#/md5sum"
   object_id:
     $ref: "#/object_id"
-  storage_urls:
-    description: A list of URLs where the file is stored in the cloud.
-    type: array
-    items:
-      type: string
-  associated_ids:
-    description: A list of UUIDs or submitter_ids associated with this file.
-    type: array
-    items:
-      type: string
   file_state:
     $ref: "#/file_state"
   error_type:

--- a/gdcdictionary/schemas/imaging_study.yaml
+++ b/gdcdictionary/schemas/imaging_study.yaml
@@ -109,10 +109,6 @@ properties:
     description: (0008, 1030) Study Description.
     type: string
 
-  study_location:
-    description: The location or geographical site of imaging, or the name of the clinic that performed the imaging study.
-    type: string
-
   study_modality:
     description: The modalities of the imaging study; derived from (0008, 0060) Modality.
     type: array

--- a/gdcdictionary/schemas/medication.yaml
+++ b/gdcdictionary/schemas/medication.yaml
@@ -77,13 +77,6 @@ properties:
       - Systemic steroids
       - Vaccine
 
-  medication_status:
-    description: Indicates if the medication is in active use.
-    enum:
-      - Active
-      - Inactive
-      - Not Reported
-
   days_to_medication_start:
     description: The number of days from the index date to the date the case started a specific medication.
     type: integer

--- a/gdcdictionary/schemas/mr_series_file.yaml
+++ b/gdcdictionary/schemas/mr_series_file.yaml
@@ -202,7 +202,7 @@ properties:
 
   diffusion_gradient_orientation:
     description: (0018, 9089) Diffusion Gradient Orientation
-    type: number
+    type: string
 
   echo_number:
     description: (0018, 0086) Echo Number


### PR DESCRIPTION
The 1.2.9 updates are described here: https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1579253762/Data+Model+Release+1.2.9+Approved
