### PR TITLE
v1.3.3: Updating data type for index_event and adding #instances to series nodes

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -83,7 +83,11 @@ properties:
 
   index_event:
     description: The event used as the anchor or start date for all temporal data elements. This acts as day 0 on a timeline of events relating to the patient.
-    type: string
+    enum:
+      - COVID 19-Test
+      - Long COVID Diagnosis
+      - Study Enrollment
+      - First Imaging Study
 
   linked_external_data:
     description: A list of all external data resources that are confirmed to have data for the case.

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -84,7 +84,7 @@ properties:
   index_event:
     description: The event used as the anchor or start date for all temporal data elements. This acts as day 0 on a timeline of events relating to the patient.
     enum:
-      - COVID 19-Test
+      - COVID-19 Test
       - Long COVID Diagnosis
       - Study Enrollment
       - First Imaging Study

--- a/gdcdictionary/schemas/cr_series_file.yaml
+++ b/gdcdictionary/schemas/cr_series_file.yaml
@@ -115,6 +115,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   pixel_spacing:
     description: (0028, 0030) Pixel Spacing
     type: array

--- a/gdcdictionary/schemas/ct_series_file.yaml
+++ b/gdcdictionary/schemas/ct_series_file.yaml
@@ -120,6 +120,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   patient_position:
     description: (0018,5100) Patient Position
     type: string

--- a/gdcdictionary/schemas/dx_series_file.yaml
+++ b/gdcdictionary/schemas/dx_series_file.yaml
@@ -117,6 +117,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   pixel_spacing:
     description: (0028, 0030) Pixel Spacing
     type: array

--- a/gdcdictionary/schemas/mg_series_file.yaml
+++ b/gdcdictionary/schemas/mg_series_file.yaml
@@ -121,6 +121,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   pixel_spacing:
     description: (0028, 0030) Pixel Spacing
     type: array

--- a/gdcdictionary/schemas/mr_series_file.yaml
+++ b/gdcdictionary/schemas/mr_series_file.yaml
@@ -228,6 +228,10 @@ properties:
     items:
       type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   number_of_temporal_positions:
     description: (0020, 0105) Number of Temporal Positions
     type: array

--- a/gdcdictionary/schemas/nm_series_file.yaml
+++ b/gdcdictionary/schemas/nm_series_file.yaml
@@ -95,6 +95,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   radiopharmaceutical:
     description: (0018,0031) Radiopharmaceutical
     type: string

--- a/gdcdictionary/schemas/pt_series_file.yaml
+++ b/gdcdictionary/schemas/pt_series_file.yaml
@@ -99,6 +99,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   radiopharmaceutical:
     description: (0018,0031) Radiopharmaceutical
     type: string

--- a/gdcdictionary/schemas/rf_series_file.yaml
+++ b/gdcdictionary/schemas/rf_series_file.yaml
@@ -115,6 +115,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   pixel_spacing:
     description: (0028, 0030) Pixel Spacing
     type: array

--- a/gdcdictionary/schemas/us_series_file.yaml
+++ b/gdcdictionary/schemas/us_series_file.yaml
@@ -89,6 +89,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   region_spatial_format:
     description: (0018,6012) Region Spatial Format
     type: array

--- a/gdcdictionary/schemas/xa_series_file.yaml
+++ b/gdcdictionary/schemas/xa_series_file.yaml
@@ -121,6 +121,10 @@ properties:
     description: (0008, 0060) Modality
     type: string
 
+  number_of_instances:
+    description: The number of instances included in this series.
+    type: integer
+
   pixel_spacing:
     description: (0028, 0030) Pixel Spacing
     type: array


### PR DESCRIPTION
These updates are based on the 1.3.3 MIDRC data model release defined [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1670381569/Data+Model+Release+1.3.3+Approved).