### PR TITLE
v1.3.4: updating radiology report link and diffusion_b_value data type.

### DIFF
--- a/gdcdictionary/schemas/mr_series_file.yaml
+++ b/gdcdictionary/schemas/mr_series_file.yaml
@@ -198,7 +198,9 @@ properties:
 
   diffusion_b_value:
     description: (0018, 9087) Diffusion b-value
-    type: number
+    type: array
+    items:
+      type: number
 
   diffusion_gradient_orientation:
     description: (0018, 9089) Diffusion Gradient Orientation

--- a/gdcdictionary/schemas/radiology_report.yaml
+++ b/gdcdictionary/schemas/radiology_report.yaml
@@ -48,7 +48,7 @@ links:
         backref: radiology_reports
         label: related_to
         target_type: imaging_study
-        multiplicity: many_to_one
+        multiplicity: many_to_many
         required: false
 
 required:


### PR DESCRIPTION
These changes are based on the approved MIDRC Data Model Release 1.3.4. The details can be found [here](https://midrc.atlassian.net/wiki/spaces/COMMITTEES/pages/1696169987/Data+Model+Release+1.3.4+Approved).
